### PR TITLE
Create kernel-osuosl yum repo for OSL mainline kernels

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,5 +1,9 @@
 ---
+verifier:
+  name: inspec
+
 suites:
   - name: default
     run_list:
       - recipe[yum-kernel-osuosl::default]
+      - recipe[yum_test]

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,5 @@
 source 'https://supermarket.chef.io'
 
+cookbook 'yum_test', path: 'test/cookbooks/yum_test'
+
 metadata

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,13 @@
+default['yum']['kernel-osuosl']['repositoryid'] = 'kernel-osuosl'
+default['yum']['kernel-osuosl']['description'] = 'OSUOSL Linux Kernel'
+default['yum']['kernel-osuosl']['enabled'] = true
+default['yum']['kernel-osuosl']['gpgcheck'] = true
+default['yum']['kernel-osuosl']['gpgkey'] = 'https://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl'
+case node['kernel']['machine']
+when 'ppc64le'
+  default['yum']['kernel-osuosl']['baseurl'] =
+    'https://ftp.osuosl.org/pub/osl/repos/yum/openpower/centos-$releasever/ppc64le/kernel-osuosl/'
+else
+  default['yum']['kernel-osuosl']['baseurl'] =
+    'https://ftp.osuosl.org/pub/osl/repos/yum/$releasever/kernel-osuosl/$basearch/'
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,4 +8,6 @@ description      'Installs/Configures yum-kernel-osuosl'
 long_description 'Installs/Configures yum-kernel-osuosl'
 version          '0.1.0'
 
+depends          'yum'
+
 supports         'centos', '~> 7.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -15,4 +15,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+yum_repository 'kernel-osuosl' do
+  node['yum']['kernel-osuosl'].each do |key, value|
+    send(key.to_sym, value)
+  end
+  only_if { platform_family?('rhel') && node['platform_version'].to_i >= 7 }
+end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -9,6 +9,42 @@ describe 'yum-kernel-osuosl::default' do
       it 'converges successfully' do
         expect { chef_run }.to_not raise_error
       end
+      case p
+      when CENTOS_7
+        it do
+          expect(chef_run).to create_yum_repository('kernel-osuosl')
+            .with(
+              repositoryid: 'kernel-osuosl',
+              description: 'OSUOSL Linux Kernel',
+              enabled: true,
+              gpgcheck: true,
+              gpgkey: 'https://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl',
+              baseurl: 'https://ftp.osuosl.org/pub/osl/repos/yum/$releasever/kernel-osuosl/$basearch/'
+            )
+        end
+        context 'ppc64le' do
+          cached(:chef_run) do
+            ChefSpec::SoloRunner.new(p) do |node|
+              node.automatic['kernel']['machine'] = 'ppc64le'
+            end.converge(described_recipe)
+          end
+          it do
+            expect(chef_run).to create_yum_repository('kernel-osuosl')
+              .with(
+                repositoryid: 'kernel-osuosl',
+                description: 'OSUOSL Linux Kernel',
+                enabled: true,
+                gpgcheck: true,
+                gpgkey: 'https://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl',
+                baseurl: 'https://ftp.osuosl.org/pub/osl/repos/yum/openpower/centos-$releasever/ppc64le/kernel-osuosl/'
+              )
+          end
+        end
+      else
+        it do
+          expect(chef_run).to_not create_yum_repository('kernel-osuosl')
+        end
+      end
     end
   end
 end

--- a/test/cookbooks/yum_test/metadata.rb
+++ b/test/cookbooks/yum_test/metadata.rb
@@ -1,0 +1,7 @@
+name             'yum_test'
+maintainer       'Oregon State University'
+maintainer_email 'chef@osuosl.org'
+license          'Apache 2.0'
+description      'Installs/Configures yum_test'
+long_description ''
+version          '0.1.0'

--- a/test/cookbooks/yum_test/recipes/default.rb
+++ b/test/cookbooks/yum_test/recipes/default.rb
@@ -1,0 +1,1 @@
+package 'kernel-osuosl'

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -1,0 +1,3 @@
+describe package('kernel-osuosl') do
+  it { should be_installed }
+end

--- a/test/integration/default/serverspec/server_spec.rb
+++ b/test/integration/default/serverspec/server_spec.rb
@@ -1,3 +1,0 @@
-require 'serverspec'
-
-set :backend, :exec


### PR DESCRIPTION
This pulls in a new repository which contains a mainline kernel custom built for
OSL systems that need something a little newer. This is currently needed on
ppc64le openstack compute nodes but may expand more later.